### PR TITLE
Add gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -16,50 +16,94 @@
 # -----------------------------------------------------------------------------
 # Source code
 # -----------------------------------------------------------------------------
-*.c   text                          # C source files
-*.cc  text                          # C++ source files
-*.cpp text                          # C++ source files
-*.cxx text                          # C++ source files
-*.h   text                          # C headers
-*.hpp text                          # C++ headers
-*.hxx text                          # C++ headers
-*.cppm text                         # C++ module interface units
-*.ixx  text                         # C++ module interface units (MSVC style)
-*.mpp  text                         # C++ module interface units
+
+# C source files
+*.c   text
+
+# C++ source files
+*.cc  text
+*.cpp text
+*.cxx text
+
+# C headers
+*.h   text
+
+# C++ headers                          
+*.hpp text                          
+*.hxx text
+
+# C++ module interface units
+*.cppm text                         
+*.ixx  text                         
+*.mpp  text                         
 
 # -----------------------------------------------------------------------------
 # Build system
 # -----------------------------------------------------------------------------
-*.cmake text                        # CMake scripts
-CMakeLists.txt text                 # CMake entry file
-Makefile text                       # Makefile
+
+# CMake scripts
+*.cmake text
+
+# CMake entry file
+CMakeLists.txt text
+
+# Makefile
+Makefile text                       
 
 # -----------------------------------------------------------------------------
 # Documentation
 # -----------------------------------------------------------------------------
-*.md text                           # Markdown files
-*.txt text                          # Plain text documentation
+
+# Markdown files
+*.md text
+
+# Plain text documentation
+*.txt text                          
 
 # -----------------------------------------------------------------------------
 # Structured data
 # -----------------------------------------------------------------------------
-*.json text                         # JSON configuration files
-*.yml  text                         # YAML configuration files
-*.yaml text                         # YAML configuration files
+
+# JSON configuration files
+*.json text
+
+# YAML configuration files
+*.yml  text
+
+# YAML configuration files
+*.yaml text                         
 
 # -----------------------------------------------------------------------------
 # Scripts
 # -----------------------------------------------------------------------------
-*.sh text eol=lf                    # Shell scripts must use LF
+
+# Shell scripts must use LF
+*.sh text eol=lf                    
 
 # -----------------------------------------------------------------------------
 # Binary files
 # -----------------------------------------------------------------------------
-*.png  binary                       # PNG images
-*.jpg  binary                       # JPEG images
-*.jpeg binary                       # JPEG images
-*.gif  binary                       # GIF images
-*.pdf  binary                       # PDF files
-*.zip  binary                       # ZIP archives
-*.tar  binary                       # TAR archives
-*.gz   binary                       # Gzip archives
+
+# PNG images
+*.png  binary                       
+
+# JPEG images
+*.jpg  binary                       
+
+# JPEG images
+*.jpeg binary                       
+
+# GIF images
+*.gif  binary                       
+
+# PDF files
+*.pdf  binary                       
+
+# ZIP archives
+*.zip  binary                       
+
+# TAR archives
+*.tar  binary                       
+
+# Gzip archives
+*.gz   binary                       

--- a/.gitattributes
+++ b/.gitattributes
@@ -11,7 +11,9 @@
 # -----------------------------------------------------------------------------
 # Default text handling
 # -----------------------------------------------------------------------------
-* text=auto eol=lf                 # Normalize text files and enforce LF line endings
+
+# Normalize text files and enforce LF line endings
+* text=auto eol=lf                 
 
 # -----------------------------------------------------------------------------
 # Source code

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,65 @@
+# -----------------------------------------------------------------------------
+# mcpp-community Git attributes
+#
+# This configuration is part of the mcpp-community style specification.
+# Repository:
+# https://github.com/mcpp-community/mcpp-style-ref
+#
+# This file ensures consistent line endings and Git behavior across platforms.
+# -----------------------------------------------------------------------------
+
+# -----------------------------------------------------------------------------
+# Default text handling
+# -----------------------------------------------------------------------------
+* text=auto eol=lf                 # Normalize text files and enforce LF line endings
+
+# -----------------------------------------------------------------------------
+# Source code
+# -----------------------------------------------------------------------------
+*.c   text                          # C source files
+*.cc  text                          # C++ source files
+*.cpp text                          # C++ source files
+*.cxx text                          # C++ source files
+*.h   text                          # C headers
+*.hpp text                          # C++ headers
+*.hxx text                          # C++ headers
+*.cppm text                         # C++ module interface units
+*.ixx  text                         # C++ module interface units (MSVC style)
+*.mpp  text                         # C++ module interface units
+
+# -----------------------------------------------------------------------------
+# Build system
+# -----------------------------------------------------------------------------
+*.cmake text                        # CMake scripts
+CMakeLists.txt text                 # CMake entry file
+Makefile text                       # Makefile
+
+# -----------------------------------------------------------------------------
+# Documentation
+# -----------------------------------------------------------------------------
+*.md text                           # Markdown files
+*.txt text                          # Plain text documentation
+
+# -----------------------------------------------------------------------------
+# Structured data
+# -----------------------------------------------------------------------------
+*.json text                         # JSON configuration files
+*.yml  text                         # YAML configuration files
+*.yaml text                         # YAML configuration files
+
+# -----------------------------------------------------------------------------
+# Scripts
+# -----------------------------------------------------------------------------
+*.sh text eol=lf                    # Shell scripts must use LF
+
+# -----------------------------------------------------------------------------
+# Binary files
+# -----------------------------------------------------------------------------
+*.png  binary                       # PNG images
+*.jpg  binary                       # JPEG images
+*.jpeg binary                       # JPEG images
+*.gif  binary                       # GIF images
+*.pdf  binary                       # PDF files
+*.zip  binary                       # ZIP archives
+*.tar  binary                       # TAR archives
+*.gz   binary                       # Gzip archives


### PR DESCRIPTION
该配置用于统一 Git 在不同平台上的文件处理行为，主要包括：
- 规范文本文件的换行符为 LF
- 启用 Git 的自动文本文件检测
- 为常见源码、脚本和文档文件设置文本属性
- 为常见二进制文件设置 binary 属性，避免错误的换行转换

该配置与 `.editorconfig` 和 `.clang-format` 共同组成完整的代码风格基础设施：
- `.editorconfig`：统一编辑器基础行为
- `.clang-format`：统一 C/C++ 代码格式
- `.gitattributes`：统一 Git 文件处理策略